### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ base64 = "0.22.1"
 copypasta = "0.10.1"
 dash-sdk = { git = "https://github.com/dashpay/platform", rev = "6a7016af671fcf1d1449e418b0e5aa5c943bde8d" }
 thiserror = "1"
-serde = "1.0.197"
-serde_json = "1.0.120"[dependencies]
-bitcoin = "0.26"
-tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+bitcoin = "0.26"
 tokio = { version = "1.36.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = tokio = { version = "1" "1.36.0", features = ["full"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 hex = { version = "0.4.3" }
 itertools = "0.13.0"


### PR DESCRIPTION
[package]
name = "dash-evo-tool"
version = "0.8.4"
license = "MIT"
edition = "2021"
default-run = "dash-evo-tool"
rust-version = "1.81"
build = "build.rs"

[build]
rustflags = [
    "-C", "target-feature=+avx,-avx2,-avx512f,-avx512cd,-avx512er,-avx512pf,-avx512bw,-avx512dq,-avx512vl"
]

[dependencies]
bip39 = { version = "2.1.0", features = ["all-languages", "rand"] }
derive_more = "1.0.0"
accesskit = "=0.16.1"
egui = { version = "0.29.1" }
egui_extras = "0.29.1"
rfd = "0.15.1"
qrcode = "0.14.1"
eframe = { version = "0.29.1", features = ["persistence"] }
strum = { version = "0.26.1", features = ["derive"] }
bs58 = "0.5.0"
base64 = "0.22.1"
copypasta = "0.10.1"
dash-sdk = { git = "https://github.com/dashpay/platform", rev = "6a7016af671fcf1d1449e418b0e5aa5c943bde8d" }
thiserror = "1"
serde = "1.0.197"
serde_json = "1.0.120"[dependencies]
bitcoin = "0.26"
tokio = { version = "1", features = ["full"] }
serde = { version = "1.0", features = ["derive"] }
serde_json = "1.0"
tokio = { version = "1.36.0", features = ["full"] }
bincode = { version = "2.0.0-rc.3", features = ["serde"] }
hex = { version = "0.4.3" }
itertools = "0.13.0"
futures = "0.3.30"
rand = "0.8"
tracing = "0.1.40"
tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
dotenvy = "0.15.7"
envy = "0.4.2"
tokio-util = "0.7.10"
chrono = "0.4"
chrono-humanize = "0.2.3"
grovedb-version = "2.0.3"
sha2 = "0.10.8"
arboard = { version = "3.4.0", default-features = false, features = [
    "windows-sys",
] }
directories = "5.0"

rusqlite = { version = "0.32.1",  features = ["functions"]}
serde_yaml = "0.9.34+deprecated"
image = { version = "0.25.2", default-features = false, features = ["png"] }
bitflags = "2.6.0"
libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }
rust-embed = "8.5.0"
zeroize = "1.8.1"
zxcvbn = "3.1.0"
argon2 = "0.5"           # For Argon2 key derivation
aes-gcm = "0.10" # For AES-256-GCM encryption
crossbeam-channel = "0.5.13"
regex = "1.11"

[target.'cfg(not(target_os = "windows"))'.dependencies]
zmq = "0.10"

[target.'cfg(target_os = "windows")'.dependencies]
zeromq = "0.4.1"

[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
native-dialog = "0.7.0"
raw-cpuid = "11.2.0"